### PR TITLE
change requirements for block_device_mappings var

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,36 +29,36 @@ Creates EC2 Image Builder recipes by wrapping CloudFormation
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-| Name      | Version   |
-|-----------|-----------|
+| Name | Version |
+|------|---------|
 | terraform | >= 0.12.2 |
-| aws       | ~> 2.44   |
+| aws | ~> 2.44 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws  | ~> 2.44 |
+| aws | ~> 2.44 |
 
 ## Inputs
 
-| Name                    | Description                                                                                                                                                                    | Type                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Default   | Required |
-|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|:--------:|
-| component\_arns         | List of component ARNs to use in recipe. Order matters                                                                                                                         | `list(string)`                                                                                                                                                                                                                                                                                                                                                                                                                                                     | n/a       |   yes    |
-| name                    | name to use for component                                                                                                                                                      | `string`                                                                                                                                                                                                                                                                                                                                                                                                                                                           | n/a       |   yes    |
-| parent\_image           | Image that the recipe should start with. SemVers is ok (and encouraged)                                                                                                        | `string`                                                                                                                                                                                                                                                                                                                                                                                                                                                           | n/a       |   yes    |
-| recipe\_version         | Version of the recipe                                                                                                                                                          | `string`                                                                                                                                                                                                                                                                                                                                                                                                                                                           | n/a       |   yes    |
-| block\_device\_mappings | [List of Maps of EBS volumes to mount](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-instanceblockdevicemapping.html) | <pre>list(<br>    object({<br>      DeviceName = string<br>      Ebs = object({<br>        DeleteOnTermination = bool<br>        Encrypted           = bool<br>        Iops                = number<br>        KmsKeyId            = string<br>        SnapshotId          = string<br>        VolumeSize          = number<br>        VolumeType          = string<br>      })<br>      NoDevice    = string<br>      VirtualName = string<br>    })<br>  )</pre> | `null`    |    no    |
-| cloudformation\_timeout | How long to wait (in minutes) for CFN to apply before giving up                                                                                                                | `number`                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `10`      |    no    |
-| description             | description of component                                                                                                                                                       | `string`                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `null`    |    no    |
-| platform                | Platform of Recipe (`Linux` or `Windows`)                                                                                                                                      | `string`                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `"Linux"` |    no    |
-| tags                    | Map of tags to use for CFN stack and component                                                                                                                                 | `map(string)`                                                                                                                                                                                                                                                                                                                                                                                                                                                      | `{}`      |    no    |
-| update                  | Whether recipe should include the `update-$platform` recipe before running other components                                                                                    | `bool`                                                                                                                                                                                                                                                                                                                                                                                                                                                             | `true`    |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| component\_arns | List of component ARNs to use in recipe. Order matters | `list(string)` | n/a | yes |
+| name | name to use for component | `string` | n/a | yes |
+| parent\_image | Image that the recipe should start with. SemVers is ok (and encouraged) | `string` | n/a | yes |
+| recipe\_version | Version of the recipe | `string` | n/a | yes |
+| block\_device\_mappings | [List of Maps of EBS volumes to mount](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-instanceblockdevicemapping.html) | `any` | `null` | no |
+| cloudformation\_timeout | How long to wait (in minutes) for CFN to apply before giving up | `number` | `10` | no |
+| description | description of component | `string` | `null` | no |
+| platform | Platform of Recipe (`Linux` or `Windows`) | `string` | `"Linux"` | no |
+| tags | Map of tags to use for CFN stack and component | `map(string)` | `{}` | no |
+| update | Whether recipe should include the `update-$platform` recipe before running other components | `bool` | `true` | no |
 
 ## Outputs
 
-| Name        | Description                         |
-|-------------|-------------------------------------|
+| Name | Description |
+|------|-------------|
 | recipe\_arn | ARN of the EC2 Image Builder Recipe |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Creates EC2 Image Builder recipes by wrapping CloudFormation
 | name | name to use for component | `string` | n/a | yes |
 | parent\_image | Image that the recipe should start with. SemVers is ok (and encouraged) | `string` | n/a | yes |
 | recipe\_version | Version of the recipe | `string` | n/a | yes |
-| block\_device\_mappings | [List of Maps of EBS volumes to mount](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-instanceblockdevicemapping.html) | `list(any)` | `null` | no |
+| block\_device\_mappings | [List of Maps of EBS volumes to mount](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-instanceblockdevicemapping.html) See examples for further usage tips. | `list(any)` | `null` | no |
 | cloudformation\_timeout | How long to wait (in minutes) for CFN to apply before giving up | `number` | `10` | no |
 | description | description of component | `string` | `null` | no |
 | platform | Platform of Recipe (`Linux` or `Windows`) | `string` | `"Linux"` | no |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Creates EC2 Image Builder recipes by wrapping CloudFormation
 | name | name to use for component | `string` | n/a | yes |
 | parent\_image | Image that the recipe should start with. SemVers is ok (and encouraged) | `string` | n/a | yes |
 | recipe\_version | Version of the recipe | `string` | n/a | yes |
-| block\_device\_mappings | [List of Maps of EBS volumes to mount](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-instanceblockdevicemapping.html) | `any` | `null` | no |
+| block\_device\_mappings | [List of Maps of EBS volumes to mount](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-instanceblockdevicemapping.html) | `list(any)` | `null` | no |
 | cloudformation\_timeout | How long to wait (in minutes) for CFN to apply before giving up | `number` | `10` | no |
 | description | description of component | `string` | `null` | no |
 | platform | Platform of Recipe (`Linux` or `Windows`) | `string` | `"Linux"` | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -49,3 +49,91 @@ module "test_recipe" {
     "arn:aws:imagebuilder:us-east-1:aws:component/reboot-test-linux/1.0.0/1"
   ]
 }
+
+
+module "test_recipe_with_partial_ebs" {
+  source  = "rhythmictech/imagebuilder-recipe/aws"
+  version = "~> 0.2.0"
+
+  description    = "Testing recipe"
+  name           = "test-recipe"
+  parent_image   = "arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x"
+  recipe_version = "1.0.0"
+  tags           = local.tags
+  update         = true
+
+  block_device_mappings = [
+    {
+      DeviceName = "/dev/xvda"
+      Ebs = {
+        DeleteOnTermination = "true"
+        VolumeSize          = 20
+        VolumeType          = "gp2"
+      }
+    }
+  ]
+
+  component_arns = [
+    module.test_component.component_arn,
+    "arn:aws:imagebuilder:us-east-1:aws:component/simple-boot-test-linux/1.0.0/1",
+    "arn:aws:imagebuilder:us-east-1:aws:component/reboot-test-linux/1.0.0/1"
+  ]
+}
+
+module "test_recipe_with_full_ebs" {
+  source  = "rhythmictech/imagebuilder-recipe/aws"
+  version = "~> 0.2.0"
+
+  description    = "Testing recipe"
+  name           = "test-recipe"
+  parent_image   = "arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x"
+  recipe_version = "1.0.0"
+  tags           = local.tags
+  update         = true
+
+  block_device_mappings = [
+    {
+      DeviceName = "/dev/xvda"
+      Ebs = {
+        DeleteOnTermination = "true"
+        Encrypted           = "true"
+        Iops                = 100
+        KmsKeyId            = "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+        SnapshotId          = "snap-1122aabb"
+        VolumeSize          = 20
+        VolumeType          = "gp2"
+      }
+    }
+  ]
+
+  component_arns = [
+    module.test_component.component_arn,
+    "arn:aws:imagebuilder:us-east-1:aws:component/simple-boot-test-linux/1.0.0/1",
+    "arn:aws:imagebuilder:us-east-1:aws:component/reboot-test-linux/1.0.0/1"
+  ]
+}
+
+module "test_recipe_with_virtual_name" {
+  source  = "rhythmictech/imagebuilder-recipe/aws"
+  version = "~> 0.2.0"
+
+  description    = "Testing recipe"
+  name           = "test-recipe"
+  parent_image   = "arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x"
+  recipe_version = "1.0.0"
+  tags           = local.tags
+  update         = true
+
+  block_device_mappings = [
+    {
+      DeviceName  = "/dev/xvda"
+      VirtualName = "ephemeral0"
+    }
+  ]
+
+  component_arns = [
+    module.test_component.component_arn,
+    "arn:aws:imagebuilder:us-east-1:aws:component/simple-boot-test-linux/1.0.0/1",
+    "arn:aws:imagebuilder:us-east-1:aws:component/reboot-test-linux/1.0.0/1"
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "block_device_mappings" {
   default     = null
-  description = "[List of Maps of EBS volumes to mount](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-instanceblockdevicemapping.html)"
+  description = "[List of Maps of EBS volumes to mount](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-instanceblockdevicemapping.html) See examples for further usage tips."
   type        = list(any)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "block_device_mappings" {
   default     = null
   description = "[List of Maps of EBS volumes to mount](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-instanceblockdevicemapping.html)"
-  type        = any
+  type        = list(any)
 }
 
 variable "cloudformation_timeout" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,23 +1,7 @@
 variable "block_device_mappings" {
   default     = null
   description = "[List of Maps of EBS volumes to mount](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-instanceblockdevicemapping.html)"
-
-  type = list(
-    object({
-      DeviceName = string
-      Ebs = object({
-        DeleteOnTermination = bool
-        Encrypted           = bool
-        Iops                = number
-        KmsKeyId            = string
-        SnapshotId          = string
-        VolumeSize          = number
-        VolumeType          = string
-      })
-      NoDevice    = string
-      VirtualName = string
-    })
-  )
+  type        = any
 }
 
 variable "cloudformation_timeout" {


### PR DESCRIPTION
Changed variable type for block_device_mappings to 'any' so that we have more freedom when configuring these (in particular, it's important to be able to not declare NoDevice, as a blank value causes the volume to be unmounted and setting it null requires some cloudformation knowledge that shouldn't be necessary to use this module)